### PR TITLE
allow filtering by active window caption prefix

### DIFF
--- a/src/InvertMouse/Inverter/InvertMouseBase.cs
+++ b/src/InvertMouse/Inverter/InvertMouseBase.cs
@@ -1,5 +1,7 @@
 ﻿using InvertMouse.Utils;
+using System;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 
 namespace InvertMouse.Inverter
@@ -13,6 +15,7 @@ namespace InvertMouse.Inverter
         public string Error { get; protected set; }
         public double Delay { get; protected set; }
         public bool WhenCursorIsHidden { get; set; }
+        public string ActiveTitlePrefix { get; set; }
 
         public decimal XMultiplier { get; set; }
         public decimal YMultiplier { get; set; }
@@ -20,7 +23,7 @@ namespace InvertMouse.Inverter
         public const decimal InvertMultiplier = -1;
         public const decimal IdentityMultiplier = 1;
 
-        protected bool IsCursorHidden()
+        bool IsCursorHidden()
         {
             var cursorInfo = new WinAPI.CURSORINFO { cbSize = Marshal.SizeOf(typeof(WinAPI.CURSORINFO)) };
             if (!WinAPI.GetCursorInfo(ref cursorInfo))
@@ -30,6 +33,36 @@ namespace InvertMouse.Inverter
             }
             return (cursorInfo.flags & WinAPI.CURSOR_SHOWING) == 0;
         }
+
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        static extern IntPtr GetForegroundWindow();
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        static extern int GetWindowTextLength(IntPtr hWnd);
+
+        bool IsActiveWindowPrefixed()
+        {
+            if (ActiveTitlePrefix == "")
+                return true;
+
+            var handle = GetForegroundWindow();
+            if (handle == null)
+                return false;
+
+            var intLength = GetWindowTextLength(handle) + 1;
+            var stringBuilder = new StringBuilder(intLength);
+            if (GetWindowText(handle, stringBuilder, intLength) <= 0)
+                return false;
+
+            var title = stringBuilder.ToString();
+            return title.StartsWith(ActiveTitlePrefix);
+        }
+
+        protected bool IsActive() => (!WhenCursorIsHidden || IsCursorHidden()) && IsActiveWindowPrefixed();
 
         protected abstract void Worker();
         public abstract string Name { get; }

--- a/src/InvertMouse/Inverter/InvertMouseInterception.cs
+++ b/src/InvertMouse/Inverter/InvertMouseInterception.cs
@@ -55,7 +55,7 @@ namespace InvertMouse.Inverter
                     if (
                         (stroke.flags &
                          (ushort)InterceptionLib.InterceptionMouseFlag.INTERCEPTION_MOUSE_MOVE_ABSOLUTE) == 0
-                        && (!WhenCursorIsHidden || IsCursorHidden())
+                        && IsActive()
                     )
                     {
                         stroke.x = (int) Math.Round(stroke.x * XMultiplier);

--- a/src/InvertMouse/Inverter/InvertMouseRawAccel.cs
+++ b/src/InvertMouse/Inverter/InvertMouseRawAccel.cs
@@ -39,7 +39,7 @@ namespace InvertMouse.Inverter
 
             while (IsRunning)
             {
-                UpdateActive(!WhenCursorIsHidden || IsCursorHidden());
+                UpdateActive(IsActive());
                 Thread.Sleep(50);
             }
         }

--- a/src/InvertMouse/MainForm.Designer.cs
+++ b/src/InvertMouse/MainForm.Designer.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace InvertMouse
 {
     partial class MainForm
@@ -31,6 +31,7 @@ namespace InvertMouse
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
+            System.Windows.Forms.Label label1;
             this.startStopBtn = new System.Windows.Forms.Button();
             this.stateLabel = new System.Windows.Forms.Label();
             this.cursorHiddenCB = new System.Windows.Forms.CheckBox();
@@ -51,6 +52,8 @@ namespace InvertMouse
             this.startStopByKeyCB = new System.Windows.Forms.CheckBox();
             this.startStopKeyTB = new System.Windows.Forms.TextBox();
             this.shieldIconPB = new System.Windows.Forms.PictureBox();
+            this.activeTitlePrefix = new System.Windows.Forms.TextBox();
+            label1 = new System.Windows.Forms.Label();
             this.contextMenuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.shieldIconPB)).BeginInit();
             this.SuspendLayout();
@@ -260,11 +263,30 @@ namespace InvertMouse
             this.shieldIconPB.Visible = false;
             this.shieldIconPB.WaitOnLoad = true;
             // 
+            // activeTitlePrefix
+            // 
+            this.activeTitlePrefix.Location = new System.Drawing.Point(146, 362);
+            this.activeTitlePrefix.Name = "activeTitlePrefix";
+            this.activeTitlePrefix.Size = new System.Drawing.Size(152, 29);
+            this.activeTitlePrefix.TabIndex = 16;
+            this.activeTitlePrefix.TextChanged += new System.EventHandler(this.activeTitlePrefix_TextChanged);
+            // 
+            // label1
+            // 
+            label1.AutoSize = true;
+            label1.Location = new System.Drawing.Point(12, 365);
+            label1.Name = "label1";
+            label1.Size = new System.Drawing.Size(128, 21);
+            label1.TabIndex = 15;
+            label1.Text = "Active title &prefix:";
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 21F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(311, 371);
+            this.ClientSize = new System.Drawing.Size(311, 404);
+            this.Controls.Add(label1);
+            this.Controls.Add(this.activeTitlePrefix);
             this.Controls.Add(this.shieldIconPB);
             this.Controls.Add(this.startStopKeyTB);
             this.Controls.Add(this.startStopByKeyCB);
@@ -321,6 +343,7 @@ namespace InvertMouse
         private System.Windows.Forms.CheckBox startStopByKeyCB;
         private System.Windows.Forms.TextBox startStopKeyTB;
         private System.Windows.Forms.PictureBox shieldIconPB;
+        private System.Windows.Forms.TextBox activeTitlePrefix;
     }
 }
 

--- a/src/InvertMouse/MainForm.cs
+++ b/src/InvertMouse/MainForm.cs
@@ -226,6 +226,7 @@ namespace InvertMouse
             minimizeToTrayCB.Checked = _options.MinimizeToTray;
             startMinimizedCB.Checked = _options.StartMinimized;
             startStopByKeyCB.Checked = _options.StartStopByKey;
+            activeTitlePrefix.Text = _options.ActiveTitlePrefix;
             SetStartStopKey(_options.StartStopKey);
             if (_options.StartStopByKey)
             {
@@ -556,6 +557,15 @@ namespace InvertMouse
         private void keyTB_MouseUp(object sender, MouseEventArgs e)
         {
             _keyBinder.MouseUp(e.Button);
+        }
+
+        private void activeTitlePrefix_TextChanged(object sender, EventArgs e)
+        {
+            if (_invertMouse != null)
+            {
+                _options.ActiveTitlePrefix = activeTitlePrefix.Text;
+                _invertMouse.ActiveTitlePrefix = _options.ActiveTitlePrefix;
+            }
         }
     }
 }

--- a/src/InvertMouse/MainForm.resx
+++ b/src/InvertMouse/MainForm.resx
@@ -141,6 +141,9 @@
         PeN8X++ZktMp3PH/y24xMJomK8N9biNCvgNLDrFDgcPEyQAAAABJRU5ErkJggg==
 </value>
   </data>
+  <metadata name="label1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAMAQEAAAAEACAAoFgAANgAAACAgAAABAAgAqAgAAF4WAAAQEAAAAQAIAGgFAAAGHwAAKAAAAEAA

--- a/src/InvertMouse/Options.cs
+++ b/src/InvertMouse/Options.cs
@@ -171,6 +171,21 @@ namespace InvertMouse
             }
         }
 
+        private string _activeTitlePrefix;
+
+        public string ActiveTitlePrefix
+        {
+            get => _activeTitlePrefix;
+            set
+            {
+                if (_activeTitlePrefix != value)
+                {
+                    _activeTitlePrefix = value;
+                    OnChanged();
+                }
+            }
+        }
+
         public event EventHandler Changed;
 
         private void OnChanged()


### PR DESCRIPTION
This adds an 'Active title prefix' textbox that only enables InvertMouse when the active window's title starts with the given prefix.